### PR TITLE
Add Kafka producer, consumers, and deployment files

### DIFF
--- a/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/consumer_print.py
+++ b/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/consumer_print.py
@@ -1,0 +1,34 @@
+import json
+from confluent_kafka import Consumer
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "purchases_kpi"
+
+def main():
+    c = Consumer({
+        "bootstrap.servers": BOOTSTRAP,
+        "group.id": "printer_group",
+        "auto.offset.reset": "earliest",
+    })
+    c.subscribe([TOPIC])
+    print(f"🖥️ Printing KPIs from {TOPIC} ...")
+
+    try:
+        while True:
+            msg = c.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                print("error", msg.error())
+                continue
+
+            data = json.loads(msg.value().decode("utf-8"))
+            print("📊 KPI:", data)
+
+    except KeyboardInterrupt:
+        print("\nStopping printer...")
+    finally:
+        c.close()
+
+if __name__ == "__main__":
+    main()

--- a/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/consumer_transform.py
+++ b/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/consumer_transform.py
@@ -1,0 +1,68 @@
+import json
+from confluent_kafka import Consumer, Producer
+
+BOOTSTRAP = "localhost:9092"
+TOPIC_IN = "purchases_raw"
+TOPIC_OUT = "purchases_enriched"
+VAT_RATE = 0.21
+
+def is_valid(p):
+    return p.get("qty", 0) > 0 and p.get("unit_price", 0) > 0
+
+def transform(p):
+    qty = int(p["qty"])
+    unit_price = float(p["unit_price"])
+    subtotal = round(qty * unit_price, 2)
+    vat = round(subtotal * VAT_RATE, 2)
+    total = round(subtotal + vat, 2)
+    return {
+        "purchase_id": p["purchase_id"],
+        "ts": p["ts"],
+        "product": p["product"],
+        "qty": qty,
+        "unit_price": unit_price,
+        "subtotal": subtotal,
+        "vat": vat,
+        "total": total,
+        "currency": p.get("currency", "EUR"),
+        "is_valid": True,
+    }
+
+def main():
+    c = Consumer({
+        "bootstrap.servers": BOOTSTRAP,
+        "group.id": "transformer_group",
+        "auto.offset.reset": "earliest",
+    })
+    p_out = Producer({"bootstrap.servers": BOOTSTRAP})
+
+    c.subscribe([TOPIC_IN])
+    print(f"📥 {TOPIC_IN} -> 📤 {TOPIC_OUT}")
+
+    try:
+        while True:
+            msg = c.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                print("error", msg.error())
+                continue
+
+            raw = json.loads(msg.value().decode("utf-8"))
+            if not is_valid(raw):
+                continue
+
+            enriched = transform(raw)
+            p_out.produce(TOPIC_OUT, value=json.dumps(enriched).encode("utf-8"))
+            p_out.poll(0)
+
+            print("🛠️ ENRICHED:", enriched)
+
+    except KeyboardInterrupt:
+        print("\nStopping transformer...")
+    finally:
+        c.close()
+        p_out.flush()
+
+if __name__ == "__main__":
+    main()

--- a/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/producer.py
+++ b/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/producer.py
@@ -1,0 +1,42 @@
+import json
+import random
+import time
+from datetime import datetime, timezone
+from confluent_kafka import Producer
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "purchases_raw"
+
+products = ["zapatillas", "camiseta", "mallas", "botella", "auriculares"]
+payments = ["card", "paypal", "bizum"]
+
+def build_purchase():
+    qty = random.randint(1, 3)
+    unit_price = round(random.uniform(5.0, 120.0), 2)
+    return {
+        "purchase_id": random.randint(10000, 99999),
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "user_id": random.randint(1, 500),
+        "product": random.choice(products),
+        "qty": qty,
+        "unit_price": unit_price,
+        "currency": "EUR",
+        "payment_method": random.choice(payments),
+    }
+
+def main():
+    p = Producer({"bootstrap.servers": BOOTSTRAP})
+    try:
+        while True:
+            data = build_purchase()
+            p.produce(TOPIC, value=json.dumps(data).encode("utf-8"))
+            p.poll(0)
+            print("RAW sent:", data)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping producer...")
+    finally:
+        p.flush()
+
+if __name__ == "__main__":
+    main()

--- a/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/requirements.txt
+++ b/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/app/requirements.txt
@@ -1,0 +1,1 @@
+confluent-kafka==2.5.3

--- a/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/images/README.MD
+++ b/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/images/README.MD
@@ -1,0 +1,98 @@
+## Kafka Post Work – Data Processing End to End
+## 1. Caso de uso
+Para este ejercicio he elegido un caso sencillo y realista: registro de compras online en tiempo real.
+La idea es simular una tienda online que genera eventos de compra continuamente y procesarlos en tiempo real para obtener métricas de negocio como:
+Número de compras por minuto
+Ingresos totales por minuto
+Ticket medio
+Este tipo de caso es uno de los usos más habituales de Kafka en entornos reales.
+## 2. Dataset seleccionado
+El dataset es simulado mediante un Producer en Python que genera eventos de compra en formato JSON.
+Cada evento contiene información como:
+purchase_id
+timestamp
+product
+quantity
+unit_price
+currency
+payment_method
+Aunque los datos son generados aleatoriamente, simulan un sistema real de compras online.
+## 3. Arquitectura implementada
+La arquitectura sigue exactamente el esquema trabajado en clase:
+Data Source (Producer en Python)
+→ Kafka Topic purchases_raw
+→ Consumer en Python (transformación)
+→ Kafka Topic purchases_enriched
+→ KSQL (agregación por ventanas de tiempo)
+→ Kafka Topic purchases_kpi
+→ Consumer final (impresión en terminal)
+En este ejercicio se utilizan:
+1 Producer
+2 Consumers
+1 Stream en KSQL
+1 Table en KSQL
+
+## 4. Ejemplos de Json de su modelo de datos json
+4.1. Evento original – Topic purchases_raw
+Mensaje generado por el Producer:
+{
+  "purchase_id": 10231,
+  "ts": "2026-02-12T09:10:05Z",
+  "product": "zapatillas",
+  "qty": 1,
+  "unit_price": 49.90,
+  "currency": "EUR"
+}
+Este mensaje representa una compra realizada en la tienda online.
+4.2 Evento transformado – Topic purchases_enriched
+Mensaje después de ser procesado por el Consumer en Python:
+{
+  "purchase_id": 10231,
+  "ts": "2026-02-12T09:10:05Z",
+  "product": "zapatillas",
+  "qty": 1,
+  "unit_price": 49.90,
+  "subtotal": 49.90,
+  "vat": 10.48,
+  "total": 60.38,
+  "currency": "EUR"
+}
+En esta fase se calculan:
+Subtotal
+IVA (21%)
+Total de la compra
+4.3. Evento agregado – Topic purchases_kpi
+Mensaje generado por KSQL con los KPIs por minuto:
+{
+  "window_start": "2026-02-12T09:10:00Z",
+  "window_end": "2026-02-12T09:11:00Z",
+  "events": 18,
+  "revenue_eur": 832.55,
+  "avg_ticket_eur": 46.25
+}
+Este mensaje muestra:
+Número de compras en ese minuto
+Ingresos totales
+Ticket medio
+
+## screenshots
+
+### 1. Creación de topics
+
+![Creación de topics](images/01_topics.png)
+
+### 2. Ingestión en tiempo real
+
+![Ingestión](images/02_ingestion.png)
+
+### 3. Transformación con Consumer
+
+![Consumer Transform](images/03_consumer_transform.png)
+
+### 4. Procesamiento con KSQL
+
+![KSQL](images/04_ksql.png)
+
+### 5. Consumer final mostrando KPIs
+
+![Final Consumer](images/05_final_consumer.png)

--- a/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/images/docker-compose.yml
+++ b/ALUMNOS/MDAB/MARTHA_SEGURA/KAFKA/images/docker-compose.yml
@@ -1,0 +1,108 @@
+services:
+
+  # =============================
+  # Servicio Zookeeper
+  # =============================
+  # Zookeeper es necesario para coordinar los brokers de Kafka.
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181  # Puerto donde Zookeeper escucha
+      ZOOKEEPER_TICK_TIME: 2000    # Intervalo de tiempo interno
+    ports:
+      - "2181:2181"                # Exponemos el puerto para acceso local
+    networks:
+      - kafka-net
+
+  # =============================
+  # Servicio Kafka
+  # =============================
+  # Broker principal de Kafka. Aquí configuramos dos listeners:
+  # - localhost: para clientes en la máquina local
+  # - kafka: para clientes dentro de la red Docker
+  kafka:
+    image: confluentinc/cp-kafka:7.3.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"                # Puerto para clientes locales
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # Listener para aceptar conexiones en todas las interfaces
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:29092
+      # Advertised listeners: cómo se anuncia el broker a los clientes
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      # Mapeo de protocolos
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      # Listener interno para comunicación entre brokers
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+
+    networks:
+      - kafka-net
+
+  # =============================
+  # Servicio Control Center
+  # =============================
+  # Interfaz web para gestionar Kafka.
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:7.3.0
+    container_name: control-center
+    depends_on:
+      - kafka
+    ports:
+      - "9021:9021"                # Puerto para acceder a la UI
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: kafka:29092
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: zookeeper:2181
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
+      PORT: 9021
+    networks:
+      - kafka-net
+
+  # =============================
+  # Servicio KSQL
+  # =============================
+  # Motor para ejecutar consultas SQL sobre datos en Kafka.
+  ksql:
+    image: confluentinc/cp-ksqldb-server:7.3.0
+    container_name: ksql
+    depends_on:
+      - kafka
+    ports:
+      - "8088:8088"                # Puerto para la API REST de KSQL
+    environment:
+      KSQL_BOOTSTRAP_SERVERS: kafka:29092  # Conexión al broker Kafka
+      KSQL_LISTENERS: http://0.0.0.0:8088  # Dirección donde escucha KSQL
+      KSQL_KSQL_SERVICE_ID: ksql_service   # Identificador del servicio KSQL
+    networks:
+      - kafka-net
+
+# =============================
+  # Servicio KSQL CLI
+  # =============================
+  # Cliente para ejecutar comandos KSQL desde la línea de comandos.
+  ksql-cli:
+    image: confluentinc/cp-ksqldb-cli:7.3.0
+    container_name: ksql-cli
+    depends_on:
+      - ksql
+    entrypoint: /bin/sh   # Para que puedas entrar al contenedor y ejecutar comandos
+    tty: true             # Permite sesión interactiva
+    networks:
+      - kafka-net
+
+# =============================
+# Red interna para comunicación entre contenedores
+# =============================
+networks:
+  kafka-net:
+    driver: bridge


### PR DESCRIPTION
Add a simple end-to-end Kafka demo: a Python producer (purchases_raw), a transformer consumer that validates and enriches messages (subtotal, VAT 21%, total) to purchases_enriched, and a final consumer that prints KPIs from purchases_kpi. Include requirements.txt (confluent-kafka==2.5.3), a docker-compose.yml to run Zookeeper, Kafka, Control Center and KSQL services, and an images/README.MD documenting the architecture, data examples and screenshots.

# PULL REQUEST

Si has llegado hasta aquí es que ya estás preparado para hacer tu PR:

Antes de continuar... asegúrate de lo siguiente:

Pon una `x` en las cajas siguientes para asegurar que has seguido el proceso:

- [x] He probado mi código y funciona en local
- [x] He validado que mi código es correcto a niveles de formato
- [x] Me he asegurado de no haber comiteado o filtrado ninguna contraseña
- [x] No he copiado mi código porque soy una persona muy responsable :-)

## Opcional:

Pega una meme que exprese como te has sentido durante tu trabajo, no es obligatorio pero es divertido :-P
